### PR TITLE
PR #1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,13 +88,32 @@ fn test_binary_search_tree(){
     println!("root node {:?}", root_node.borrow().key);
 
     //successor test
-    let mut successor_node = BstNode::tree_successor(&root_node);
-    print!("\nSuccessor of node 15 is ");
-    println!("{:?}", successor_node);
+    let query_keys = vec![
+        2, // min_node, should return its parent Some(3)
+        20, // max_node, should return None
+        15, // root_node, should return the minimum of its right tree
+        
+        // test case for node with empty right child
+        // should return a parent of the node's ancestor if it's a left child of the parent
+        13,
 
-    successor_node = BstNode::tree_successor_simpler(&min_node);
-    print!("Successor of node 2 is ");
-    println!("{:?}", successor_node);
+        9, 7, // other keys
+        22 // non-existent key
+    ];
+
+    for &key in query_keys.iter() {
+        if let Some(node) = rootlink.borrow().tree_search(key) {
+            print!("successor of node ({}) is ", key);
+
+            if let Some(successor) = BstNode::tree_successor(&node) {
+                println!("{:?}", successor.borrow().key);
+            } else {
+                println!("not found");
+            }
+        } else {
+            println!("node with key of {} does not exist, failed to get successor", key)
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,28 +63,38 @@ fn test_binary_search_tree(){
     generate_dotfile_bst(&rootlink, main_tree_path);
 
     //tree search test
-    let node_result = rootlink.borrow().tree_search(9);
-    println!("tree search result {:?}", node_result);
+    let search_keys = vec![15, 9, 22];
+
+    for &key in search_keys.iter() {
+        print!("tree search result of key {} is ", key);
+        
+        if let Some(node_result) = rootlink.borrow().tree_search(key) {
+            println!("found -> {:?}", node_result.borrow().key);
+        } else {
+            println!("not found");
+        }
+    }
+    
     //min test
     let min_node = rootlink.borrow().minimum();
-    println!("minimum result {:?}", min_node);
+    println!("minimum result {:?}", min_node.borrow().key);
+
     //max test
     let max_node = rootlink.borrow().maximum();
-    println!("maximum result {:?}", max_node);
+    println!("maximum result {:?}", max_node.borrow().key);
+
     //root node get test
     let root_node = BstNode::get_root(&max_node);
-    println!();
-    println!("root node {:?}", root_node);
+    println!("root node {:?}", root_node.borrow().key);
 
     //successor test
     let mut successor_node = BstNode::tree_successor(&root_node);
-    print!("Successor of node 15 is ");
+    print!("\nSuccessor of node 15 is ");
     println!("{:?}", successor_node);
 
     successor_node = BstNode::tree_successor_simpler(&min_node);
     print!("Successor of node 2 is ");
     println!("{:?}", successor_node);
-
 }
 
 #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::tool::generate_dotfile_bst;
 
 fn main() {
     //turn on to test the old code
-    //test_binary_tree();
+    // test_binary_tree();
     test_binary_search_tree();
 }
 
@@ -51,9 +51,9 @@ fn test_binary_search_tree(){
         if let Some(second_right_subtree_link) = second_right_subtree{
             second_right_subtree_link.borrow_mut().add_right_child(second_right_subtree_link, 13);
 
-            let third_left_subtree = &second_right_subtree_link.borrow().left;
+            let third_left_subtree = &second_right_subtree_link.borrow().right;
             if let Some(third_left_subtree_link) = third_left_subtree{
-                third_left_subtree_link.borrow_mut().add_right_child(third_left_subtree_link, 9);
+                third_left_subtree_link.borrow_mut().add_left_child(third_left_subtree_link, 9);
             }
         }
     }
@@ -63,7 +63,7 @@ fn test_binary_search_tree(){
     generate_dotfile_bst(&rootlink, main_tree_path);
 
     //tree search test
-    let node_result = rootlink.borrow().tree_search(&3);
+    let node_result = rootlink.borrow().tree_search(9);
     println!("tree search result {:?}", node_result);
     //min test
     let min_node = rootlink.borrow().minimum();
@@ -87,6 +87,7 @@ fn test_binary_search_tree(){
 
 }
 
+#[allow(dead_code)]
 fn test_binary_tree() {
     //create the nodelink of the root node
     let rootlink: NodeLink = Node::new_nodelink(5);

--- a/src/structure/bst.rs
+++ b/src/structure/bst.rs
@@ -63,12 +63,12 @@ impl BstNode {
     }
 
     //search the current tree which node fit the value
-    pub fn tree_search(&self, value: &i32) -> Option<BstNodeLink> {
+    pub fn tree_search(&self, value: i32) -> Option<BstNodeLink> {
         if let Some(key) = self.key {
-            if key == *value {
+            if key == value {
                 return Some(self.get_bst_nodelink_copy());
             }
-            if *value < key && self.left.is_some() {
+            if value < key && self.left.is_some() {
                 return self.left.as_ref().unwrap().borrow().tree_search(value);
             } else if self.right.is_some() {
                 return self.right.as_ref().unwrap().borrow().tree_search(value);

--- a/src/structure/bst.rs
+++ b/src/structure/bst.rs
@@ -112,43 +112,40 @@ impl BstNode {
 
     /**
      * Find node successor according to the book
-     * Possible to return self, if x_node is the highest key in the tree
+     * Should return None, if x_node is the highest key in the tree
      */
-    pub fn tree_successor(x_node: &BstNodeLink) -> BstNodeLink {
-        let mut x_node = x_node;
+    pub fn tree_successor(x_node: &BstNodeLink) -> Option<BstNodeLink> {
+        // directly check if the node has a right child, otherwise go to the next block
         if let Some(right_node) = &x_node.borrow().right {
-            return right_node.borrow().minimum();
-        }
-        let mut y_node = BstNode::upgrade_weak_to_strong(x_node.borrow_mut().parent.clone());
-        let mut y_node2: Rc<RefCell<BstNode>>;
-        while let Some(y_node_val) = y_node.clone() {
-            if let Some(next_right) = &y_node_val.borrow().right {
-                //meaning we are coming from the right, seek further up
-                if y_node_val.borrow().parent.is_some()
-                    && BstNode::is_node_match(x_node, next_right)
-                {
-                    y_node2 = y_node.clone().unwrap();
-                    x_node = &y_node2;
-                    let y_parent = y_node_val.borrow_mut().parent.clone().unwrap();
-                    y_node = Some(
-                        BstNode::upgrade_weak_to_strong(Some(y_parent))
-                            .clone()
-                            .unwrap(),
-                    );
+            return Some(right_node.borrow().minimum());
+        } 
+        
+        // empty right child case
+        else { 
+            let mut x_node = x_node;
+            let mut y_node = BstNode::upgrade_weak_to_strong(x_node.borrow().parent.clone());
+            let mut temp: BstNodeLink;
+
+            while let Some(ref exist) = y_node {
+                if let Some(ref left_child) = exist.borrow().left {
+                    if BstNode::is_node_match(left_child, x_node) {
+                        return Some(exist.clone());
+                    }
                 }
+
+                temp = y_node.unwrap();
+                x_node = &temp;
+                y_node = BstNode::upgrade_weak_to_strong(temp.borrow().parent.clone());
             }
+
+            None    
         }
-        //in case our sucessor traversal yield root, means self is the highest key
-        if BstNode::is_node_match_option(y_node.clone(), Some(BstNode::get_root(&x_node))) {
-            return x_node.clone();
-        }
-        //guaranteed y_node is parent of x since if root will be catched on previous block
-        return y_node.clone().unwrap();
     }
 
     /**
      * Alternate simpler version of tree_successor that made us of is_nil checking
      */
+    #[allow(dead_code)]
     pub fn tree_successor_simpler(x_node: &BstNodeLink) -> BstNodeLink{
         //create a shadow of x_node so it can mutate
         let mut x_node = x_node;

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -34,6 +34,7 @@ pub mod tree {
         /**
          * Consumptive, this function can only be called once for the whole lifetime
          */
+        #[allow(dead_code)]
         fn get_nodelink(self) -> NodeLink {
             Rc::new(RefCell::new(self))
         }
@@ -88,6 +89,7 @@ pub mod tree {
         /**
          * Unused
          */
+        #[allow(dead_code)]
         fn is_node_match_weak_strong(node1: Option<WeakNodeLink>, node2: Option<NodeLink>) -> bool {
             let node1s: Option<Rc<RefCell<Node>>> = Node::upgrade_weak_to_strong(node1);
             if node1s.is_none() && node2.is_none() {


### PR DESCRIPTION
Sir, I have PR related to the latest code base that might be useful if considered. Details as follows:

1. There is an incorrect property access in the third_left_subtree logic. Instead of accessing .left, it should use .right, since 13 is greater than 7. When adding key 9 to the node with key 13, it should correctly use the add_left_child function, as 9 is less than 13.

2. To avoid a potential panic, null (or None) case handling should be implemented when using the tree_search function.

3. I’ve expanded the successor test cases to include scenarios where the result should be None, such as when searching for the successor of the highest key in the tree. Aside from that, I’ve kept your existing approach using a "temporary" variable to work around Rust's borrowing rules when dealing with lifetimes.

4. I recommend using the tree_successor function as it's close to Idiomatic Rust.

I look forward to your feedback and suggestions for further improvement. Thank you!